### PR TITLE
Remove pytz dependency

### DIFF
--- a/attendence.py
+++ b/attendence.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import discord
-import pytz
+from zoneinfo import ZoneInfo
 
 from discord.ext import commands
 from discord import app_commands
@@ -25,14 +25,12 @@ class Attendence(commands.Cog):
         user = init_load_user(interaction)  # 사용자 로드
 
         # 현재 시간과 출석 기록 확인
-        korea_tz = pytz.timezone("Asia/Seoul")
+        korea_tz = ZoneInfo("Asia/Seoul")
         current_time_kst = datetime.now(korea_tz)  # 한국 시간으로 현재 시간 얻기
         today = current_time_kst.date()
 
         # 마지막 출석 날짜 확인
-        last_attendance_date = datetime.fromtimestamp(
-            user.login_record, korea_tz
-        ).date()
+        last_attendance_date = user.login_record.date()
 
         # 이미 오늘 출석한 경우 처리
         if last_attendance_date == today:
@@ -43,7 +41,7 @@ class Attendence(commands.Cog):
 
         # 출석 처리 및 골드 지급
         user.update_balance(config().daily_reward)  # 골드 업데이트
-        user.login_record = current_time_kst.timestamp()  # 로그인 기록 추가
+        user.login_record = current_time_kst  # 로그인 기록 추가
 
         # 출석 완료 메시지
         await interaction.followup.send(

--- a/data.py
+++ b/data.py
@@ -2,7 +2,7 @@ from fractions import Fraction
 import logging
 from typing import Self
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from db_connection import db
 from sharing_codes import config
@@ -457,14 +457,14 @@ class UserData:
         return True
 
     @property
-    def login_record(self):
+    def login_record(self) -> datetime:
         return self.__retrieve_db()["login_record"]
 
     @login_record.setter
-    def login_record(self, record_time):
+    def login_record(self, record_time: datetime):
         users_collection().update_one(
             {"discord_id": self.__discord_id},
-            {"$set": {"login_record": record_time}},
+            {"$set": {"login_record": record_time.astimezone(timezone.utc)}},
             upsert=True,
         )
 
@@ -517,7 +517,7 @@ class UserData:
         adc: int = -1,
         sup: int = -1,
         balance: int = 0,
-        login_record: int = 0,
+        login_record: datetime = datetime(1970, 1, 1, tzinfo=timezone.utc),
     ) -> tuple["UserData", bool]:
         if id < 0:
             return None, False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 discord.py
-pytz
+tzdata
 pymongo
 black


### PR DESCRIPTION
pytz is [stupid](https://post.bytes.com/forum/topic/python/602953), and there is a built-in replacement for it.
Thus, this PR removes it.